### PR TITLE
Object left behind continues to be pushed/pulled

### DIFF
--- a/Assets/Scripts/Interactions/SwitchWithRequirements.cs
+++ b/Assets/Scripts/Interactions/SwitchWithRequirements.cs
@@ -32,6 +32,7 @@ public class SwitchWithRequirements : SwitchObject
     {
         foreach (var req in _requirements)
         {
+            if (req.Switch == null) continue;
             Gizmos.color = req.IsMet ? Color.green : Color.red;
             Gizmos.DrawLine(transform.position, req.Switch.transform.position);
         }


### PR DESCRIPTION
[Check if object being pushed/pulled still in range](https://github.com/Rafinha-uwu/LUCE/commit/88bfa300591a69bab9e0a4559fbdd85d21546d3f)
- Stored the direction of the object being pushed/pulled.
- Stored flip in static property to reduce Find and GetComponent calls.
- Moved logic of setting a new current object from NewObjectCheck to SetNewCurrent method (new). 
- Small fix in SwitchWithRequirements to ignore Requirements without Switch in method OnDrawGizmosSelected.