### PR TITLE
Code Randomizer should update all requirements

### DIFF
--- a/Assets/Scripts/Interactions/Code.cs
+++ b/Assets/Scripts/Interactions/Code.cs
@@ -33,7 +33,12 @@ public class Code : SwitchWithRequirements
         Requirement[] requirementsToChange = _requirements.OrderBy(x => Random.value).Take(changes).ToArray();
 
         // Change the requirements and force a state change
-        foreach (var req in requirementsToChange) req.RequiredState = !req.RequiredState;
+        foreach (var req in _requirements)
+        {
+            bool switchIsOn = req.Switch.IsOn;
+            bool needsToChange = requirementsToChange.Contains(req);
+            req.RequiredState = needsToChange ? !switchIsOn : switchIsOn;
+        }
         OnSwitchStateChange(null, false);
 
         // Update the sprites


### PR DESCRIPTION
Explaination (#83):
- Current behavior:
  - Set the RequiredState of some requirements to the flipped value.
- What should be:
  - Set the RequiredState of all requirements to the value (or flipped value) of IsOn.

[RequiredState setted to IsOn (or flipped) value](https://github.com/Rafinha-uwu/LUCE/commit/f97572aa01a6f8da9c599aa66ac92509a2f2b10e)