### PR TITLE
Fix StartMenu sounds + Fix Scared Death + More locations and FMOD Events

### DIFF
--- a/Assets/Scripts/Interactions/HoldableItem.cs
+++ b/Assets/Scripts/Interactions/HoldableItem.cs
@@ -57,8 +57,12 @@ public class HoldableItem : MonoBehaviour, ISavable
             ItemType.Item => FMODManager.Instance.EventDatabase.KeyPickup,
             ItemType.Teddy => FMODManager.Instance.EventDatabase.TeddyPickup,
             ItemType.Key => FMODManager.Instance.EventDatabase.KeyPickup,
+            ItemType.Camera => FMODManager.Instance.EventDatabase.CameraPickup,
             ItemType.Polaroid => FMODManager.Instance.EventDatabase.PolaroidPickup,
             ItemType.PolaroidNarrative1 => FMODManager.Instance.EventDatabase.Narrative1Pickup,
+            ItemType.PolaroidNarrative2 => FMODManager.Instance.EventDatabase.Narrative2Pickup,
+            ItemType.PolaroidNarrative3 => FMODManager.Instance.EventDatabase.Narrative3Pickup,
+            ItemType.PolaroidNarrative4 => FMODManager.Instance.EventDatabase.Narrative4Pickup,
             // ...
             _ => null
         };
@@ -72,8 +76,12 @@ public class HoldableItem : MonoBehaviour, ISavable
         Item,
         Teddy,
         Key,
+        Camera,
         Polaroid,
         PolaroidNarrative1,
+        PolaroidNarrative2,
+        PolaroidNarrative3,
+        PolaroidNarrative4,
         //...
     }
 

--- a/Assets/Scripts/Other/Hand.cs
+++ b/Assets/Scripts/Other/Hand.cs
@@ -106,7 +106,7 @@ public class Hand : MonoBehaviour, IChildTriggerParent, ISavable
     {
         move = false;
         _animator.Play("Grab");
-        PauseManager.Instance.PauseGame();
+        PauseManager.Instance.PauseGame(false); // Pause the game but not the sounds
         yield return new WaitForSecondsRealtime(0.4f);
 
         _black2Animator.SetBool("Dark", true);

--- a/Assets/Scripts/Other/PauseManager.cs
+++ b/Assets/Scripts/Other/PauseManager.cs
@@ -22,7 +22,7 @@ public class PauseManager : MonoBehaviour
     private void Start() => ResumeGame();
 
 
-    public void PauseGame()
+    public void PauseGame(bool pauseSounds = true)
     {
         if (IsPaused) return;
         IsPaused = true;
@@ -30,7 +30,7 @@ public class PauseManager : MonoBehaviour
         // Set the time scale to 0 and pause the player input
         Time.timeScale = 0;
         if (InputHandler != null) InputHandler.PauseInput();
-        FMODManager.Instance.PauseSounds();
+        if (pauseSounds) FMODManager.Instance.PauseSounds();
     }
 
     public void ResumeGame()

--- a/Assets/Scripts/Other/StartMenu.cs
+++ b/Assets/Scripts/Other/StartMenu.cs
@@ -1,4 +1,5 @@
 using FMOD.Studio;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -28,8 +29,11 @@ public class StartMenu : MonoBehaviour
 
     private void Start()
     {
-        _startGameCutsceneInstance = FMODManager.Instance.CreateEventInstance(FMODManager.Instance.EventDatabase.StartGameCutscene);
         if (_continueButton != null) _continueButton.SetActive(SaveManager.Instance.SaveExists());
+        _startGameCutsceneInstance = FMODManager.Instance.CreateEventInstance(FMODManager.Instance.EventDatabase.StartGameCutscene);
+        
+        FMODManager.Instance.PauseSounds();
+        StartCoroutine(StopExternalSounds());
     }
 
     private void OnDestroy()
@@ -46,7 +50,9 @@ public class StartMenu : MonoBehaviour
         if (_menuAnimator != null) _menuAnimator.SetBool("Start", true);
 
         if (_backgroundPlayer != null) _backgroundPlayer.StopBGM();
+
         _startGameCutsceneInstance?.start();
+        _startGameCutsceneInstance?.setPaused(false);
 
         Invoke(nameof(Load), 16);
     }
@@ -55,6 +61,9 @@ public class StartMenu : MonoBehaviour
     {
         if (_backgroundPlayer != null) _backgroundPlayer.StopBGM();
         _startGameCutsceneInstance?.stop(STOP_MODE.ALLOWFADEOUT);
+
+        FMODManager.Instance.ResumeSounds();
+
         SceneManager.LoadScene(GAME_SCENE);
     }
 
@@ -79,6 +88,13 @@ public class StartMenu : MonoBehaviour
 #else
         Application.Quit();
 #endif
+    }
+
+
+    private IEnumerator StopExternalSounds()
+    {
+        yield return new WaitForEndOfFrame();
+        if (_backgroundPlayer != null) _backgroundPlayer.PlayBGM();
     }
 }
 

--- a/Assets/Scripts/Player/Scared.cs
+++ b/Assets/Scripts/Player/Scared.cs
@@ -249,8 +249,8 @@ public class Scared : MonoBehaviour
 
             else
             {
-                Invoke("Death", 0.5f);
-                Darkness.GetComponent<Animator>().SetBool("Dark", true);
+                StartCoroutine(ScaredDeath());
+                if (Darkness != null) Darkness.GetComponent<Animator>().SetBool("Dark", true);
             }
         }
         else
@@ -301,6 +301,15 @@ public class Scared : MonoBehaviour
     }
     */
 
+    private System.Collections.IEnumerator ScaredDeath()
+    {
+        timerIsRunning = false;
+        ScaredCountDown = ScaredTime;
+
+        yield return new WaitForSeconds(0.5f);
+        Death();
+    }
+
     public void Death()
     {
         PlayDeathSound();
@@ -331,7 +340,7 @@ public class Scared : MonoBehaviour
         if (_scared1Animator != null) _scared1Animator.SetBool("Scared", false);
         if (_scared2Animator != null) _scared2Animator.SetBool("Scared", false);
         if (_scared3Animator != null) _scared3Animator.SetBool("Scared", false);
-        Darkness.GetComponent<Animator>().SetBool("Dark", false);
+        if (Darkness != null) Darkness.GetComponent<Animator>().SetBool("Dark", false);
         // check2 = true;
         // check = true;
         // this.transform.position = LastCheck;

--- a/Assets/Scripts/Sound/BackgroundPlayer.cs
+++ b/Assets/Scripts/Sound/BackgroundPlayer.cs
@@ -32,6 +32,12 @@ public class BackgroundPlayer : MonoBehaviour
         BunkerDown2,
         BunkerRight,
         Tunnel,
+        PuzzleEye,
+        Tunnel2,
+        Hand,
+        Tunnel3,
+        RealBasement,
+        Escape,
         // ...
     }
 }

--- a/Assets/Scripts/Sound/FMODEventDatabase.cs
+++ b/Assets/Scripts/Sound/FMODEventDatabase.cs
@@ -16,6 +16,7 @@ public class FMODEventDatabase : ScriptableObject
     [field: Header("Cutscenes")]
     [field: SerializeField] public EventReference StartGameCutscene { get; private set; }
     [field: SerializeField] public EventReference EndGameCutscene { get; private set; }
+    // ...
 
     // Player
     [field: Header("Player")]
@@ -50,10 +51,15 @@ public class FMODEventDatabase : ScriptableObject
     [field: SerializeField] public EventReference KeyPickup { get; private set; }
     [field: SerializeField] public EventReference KeyGroundHit { get; private set; }
     [field: SerializeField] public EventReference KeyUnlock { get; private set; }
+    [field: SerializeField] public EventReference CameraPickup { get; private set; }
+    // ...
 
     // Polaroids
     [field: Header("Polaroids")]
     [field: SerializeField] public EventReference PolaroidPickup { get; private set; }
     [field: SerializeField] public EventReference Narrative1Pickup { get; private set; }
+    [field: SerializeField] public EventReference Narrative2Pickup { get; private set; }
+    [field: SerializeField] public EventReference Narrative3Pickup { get; private set; }
+    [field: SerializeField] public EventReference Narrative4Pickup { get; private set; }
     // ...
 }

--- a/Assets/Scripts/Sound/FMODManager.cs
+++ b/Assets/Scripts/Sound/FMODManager.cs
@@ -13,6 +13,8 @@ public class FMODManager : MonoBehaviour
     private readonly List<EventInstance> _eventInstances = new();
     private readonly List<StudioEventEmitter> _eventEmitters = new();
 
+    private bool _isPaused = false;
+
 
     private void Awake()
     {
@@ -31,6 +33,7 @@ public class FMODManager : MonoBehaviour
 
     public void PlayOneShot(EventReference eventReference, Vector3 position = default)
     {
+        if (_isPaused) return;
         RuntimeManager.PlayOneShot(eventReference, position);
     }
 
@@ -39,6 +42,7 @@ public class FMODManager : MonoBehaviour
         try
         {
             EventInstance eventInstance = RuntimeManager.CreateInstance(eventReference);
+            eventInstance.setPaused(_isPaused);
 
             _eventInstances.Add(eventInstance);
             return eventInstance;
@@ -58,12 +62,15 @@ public class FMODManager : MonoBehaviour
         eventEmitter.OverrideMinDistance = minDistance;
         eventEmitter.OverrideMaxDistance = maxDistance;
 
+        eventEmitter.EventInstance.setPaused(_isPaused);
+
         _eventEmitters.Add(eventEmitter);
         return eventEmitter;
     }
 
     public void PlayOneShotAttached(EventReference eventReference, GameObject gameObject)
     {
+        if (_isPaused) return;
         RuntimeManager.PlayOneShotAttached(eventReference, gameObject);
     }
 
@@ -86,15 +93,13 @@ public class FMODManager : MonoBehaviour
     }
 
 
-    public void PauseSounds()
-    {
-        _eventInstances.ForEach(e => e.setPaused(true));
-        _eventEmitters.ForEach(e => e.EventInstance.setPaused(true));
-    }
+    public void PauseSounds() => SetPaused(true);
+    public void ResumeSounds() => SetPaused(false);
 
-    public void ResumeSounds()
+    private void SetPaused(bool paused)
     {
-        _eventInstances.ForEach(e => e.setPaused(false));
-        _eventEmitters.ForEach(e => e.EventInstance.setPaused(false));
+        _isPaused = paused;
+        _eventInstances.ForEach(e => e.setPaused(_isPaused));
+        _eventEmitters.ForEach(e => e.EventInstance.setPaused(_isPaused));
     }
 }

--- a/Assets/Scripts/Sound/StartMenuBackgroundPlayer.cs
+++ b/Assets/Scripts/Sound/StartMenuBackgroundPlayer.cs
@@ -8,7 +8,12 @@ public class StartMenuBackgroundPlayer : MonoBehaviour
     private void Start()
     {
         _bgmInstance = FMODManager.Instance.CreateEventInstance(FMODManager.Instance.EventDatabase.StartMenuBGM);
+    }
+
+    public void PlayBGM()
+    {
         _bgmInstance?.start();
+        _bgmInstance?.setPaused(false);
     }
 
     public void StopBGM()


### PR DESCRIPTION
- [Stopped sounds on StartMenu + Fix Scared Death](https://github.com/Rafinha-uwu/LUCE/commit/ebd48143926d4ae4af1c137fc3498fb813483b3a)
  - ScaredDeath stops time running and resets ScardTime before waiting.
  - Pause/Resume Sounds on StartMenu.
  - Added variable isPaused on FMODManager.
  - Created method PlayBGM on StartMenuBackgroundPlayer.
- [Added new Locations and ItemTypes + More Events](https://github.com/Rafinha-uwu/LUCE/commit/feabefe3987922c1f905d96e4112706d8737bee3) + [Hand Pause don't stop sound](https://github.com/Rafinha-uwu/LUCE/commit/b420358f13d41508989b06f133f2f899704c1130)