### PR TITLE
Changed InputHandler to keep list of stoppers

### DIFF
--- a/Assets/Scripts/Interactions/Elevator.cs
+++ b/Assets/Scripts/Interactions/Elevator.cs
@@ -62,7 +62,7 @@ public class Elevator : SwitchWithRequirements
         SetCurrentFloor(_currentIndex + 1);
 
         // Stop the player from moving
-        if (_inputHandler != null) _inputHandler.PauseInput();
+        if (_inputHandler != null) _inputHandler.PauseInput(this);
     }
 
 
@@ -80,7 +80,7 @@ public class Elevator : SwitchWithRequirements
     public void OnAnimationEnd()
     {
         // Resume the player's movement
-        if (_inputHandler != null) _inputHandler.ResumeInput();
+        if (_inputHandler != null) _inputHandler.ResumeInput(this);
 
         // Reset the trigger
         _animator.ResetTrigger(ANIMATOR_PARAMETER_NEXT);

--- a/Assets/Scripts/Other/Hand.cs
+++ b/Assets/Scripts/Other/Hand.cs
@@ -73,6 +73,7 @@ public class Hand : MonoBehaviour, IChildTriggerParent, ISavable
     {
         start = false;
         move = false;
+        _inputHandler.ResumeInput(this);
 
         Block2.SetActive(false);
         Sprite.SetActive(false);
@@ -129,14 +130,13 @@ public class Hand : MonoBehaviour, IChildTriggerParent, ISavable
     {
         move = false;
         _animator.Play("Grab");
-        _inputHandler.PauseInput();
+        _inputHandler.PauseInput(this);
         yield return new WaitForSeconds(0.4f);
 
         _black2Animator.SetBool("Dark", true);
         yield return new WaitForSeconds(1f);
 
         move = true;
-        _inputHandler.ResumeInput();
         _scared.Death();
     }
 
@@ -154,13 +154,11 @@ public class Hand : MonoBehaviour, IChildTriggerParent, ISavable
         {
             HelpCam.GetComponent<Animator>().Play("Idle 1");
         }
-        Block.SetActive(false); CameraShake.instance.CameraShaking(impulseSource);
-        Invoke("HelpKill", 1);
+        Block.SetActive(false);
+        CameraShake.instance.CameraShaking(impulseSource);
+        Invoke(nameof(HelpKill), 1);
         yield return new WaitForSeconds(3f);
         move = true;
-
-        
-
     }
 
     public void HelpKill() => HelpCam.SetActive(false);
@@ -192,7 +190,6 @@ public class Hand : MonoBehaviour, IChildTriggerParent, ISavable
     {
         public float[] Position;
         public bool Started;
-        public bool Stopped;
     }
 }
 

--- a/Assets/Scripts/Other/PauseManager.cs
+++ b/Assets/Scripts/Other/PauseManager.cs
@@ -29,7 +29,7 @@ public class PauseManager : MonoBehaviour
 
         // Set the time scale to 0 and pause the player input
         Time.timeScale = 0;
-        if (InputHandler != null) InputHandler.PauseInput();
+        if (InputHandler != null) InputHandler.PauseInput(this);
         if (pauseSounds) FMODManager.Instance.PauseSounds();
     }
 
@@ -40,7 +40,7 @@ public class PauseManager : MonoBehaviour
 
         // Set the time scale to 1 and resume the player input
         Time.timeScale = 1;
-        if (InputHandler != null) InputHandler.ResumeInput();
+        if (InputHandler != null) InputHandler.ResumeInput(this);
         FMODManager.Instance.ResumeSounds();
     }
 

--- a/Assets/Scripts/Player/InputHandler.cs
+++ b/Assets/Scripts/Player/InputHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -10,7 +11,7 @@ public class InputHandler : MonoBehaviour
     private static readonly string UI_ACTION_MAP = "UI";
 
     [SerializeField] private float _jumpBuffer;
-    private int _pauseCounter = 0;
+    private readonly List<object> _stoppers = new();
 
     public float HorizontalInput { get; private set; }
     public float JumpBufferCounter { get; private set; }
@@ -24,19 +25,19 @@ public class InputHandler : MonoBehaviour
 
     private void Awake() => _playerInput = GetComponent<PlayerInput>();
 
-    public void ResumeInput()
+    public void ResumeInput(object stopper)
     {
-        // Resume the input if the pause counter is 0
-        if (_pauseCounter > 0) _pauseCounter--;
-        if (_pauseCounter == 0) _playerInput.SwitchCurrentActionMap(PLAYER_ACTION_MAP);
+        // Remove the stopper from the list + Resume the input if there is no stoppers
+        _stoppers.Remove(stopper);
+        if (_stoppers.Count == 0) _playerInput.SwitchCurrentActionMap(PLAYER_ACTION_MAP);
     }
 
-    public void PauseInput()
+    public void PauseInput(object stopper)
     {
-        // Count the number of times the input is paused
+        // Add the stopper to the list + Pause the input + Clear the jump buffer
+        _stoppers.Add(stopper);
         _playerInput.SwitchCurrentActionMap(UI_ACTION_MAP);
         ClearJumpBuffer();
-        _pauseCounter++;
     }
 
 


### PR DESCRIPTION
Fixes bug where player dies to both dark and grab, resulting in the input stopping infinitely.

[Changed InputHandler to keep list of stoppers](https://github.com/Rafinha-uwu/LUCE/commit/9d570656a86f03470c69e1b8384e645ff9296d72)
- Changed Resume/PauseInput methods to accept object as parameter.
- Input is resumed when stoppers is empty (instead of number of calls).